### PR TITLE
Fix error in warning code, made when porting from rstatic

### DIFF
--- a/static/lib.sh
+++ b/static/lib.sh
@@ -571,7 +571,7 @@ __distribution_static__ck_syntax_python_guessbin() {
     local reqs
     local it_was_2='echo /usr/bin/python2; return 0'
     local it_was_3='echo /usr/bin/python3; return 0'
-    local it_was_P='echo /usr/bin/platform-python; return 0'
+    local it_was_P='echo /usr/libexec/platform-python; return 0'
     __distribution_static__opt pybin && return 0
     case $path in
         /usr/lib/python2*) eval "$it_was_2" ;;
@@ -589,7 +589,7 @@ __distribution_static__ck_syntax_python_guessbin() {
         eval "$it_was_2"
     elif grep -q '/usr/bin/python3\>' <<<"$reqs"; then
         eval "$it_was_3"
-    elif grep -q '/usr/bin/platform-python\>' <<<"$reqs"; then
+    elif grep -q '/usr/libexec/platform-python\>' <<<"$reqs"; then
         eval "$it_was_P"
     else
         rlLogWarning "$(distribution_static__cmt): could not guess python binary path, falling back to /usr/bin/python"

--- a/static/lib.sh
+++ b/static/lib.sh
@@ -592,9 +592,8 @@ __distribution_static__ck_syntax_python_guessbin() {
     elif grep -q '/usr/bin/platform-python\>' <<<"$reqs"; then
         eval "$it_was_P"
     else
-        rlLogWarning \
-            "$(distribution_static__cmt): could not guess python binary path, falling back to /usr/bin/python" \
-            "hint: to avoid this warning, add 'syntax.python:pybin=/correct/binary' to distribution_static__bltnopts."
+        rlLogWarning "$(distribution_static__cmt): could not guess python binary path, falling back to /usr/bin/python"
+        rlLogWarning "hint: to avoid this warning, add 'syntax.python:pybin=/correct/binary' to distribution_static__bltnopts."
         echo "/usr/bin/python"
         return 2
     fi

--- a/static/lib.sh
+++ b/static/lib.sh
@@ -593,7 +593,7 @@ __distribution_static__ck_syntax_python_guessbin() {
         eval "$it_was_P"
     else
         rlLogWarning \
-            "$(rstatic__hint): could not guess python binary path, falling back to /usr/bin/python" \
+            "$(distribution_static__cmt): could not guess python binary path, falling back to /usr/bin/python" \
             "hint: to avoid this warning, add 'syntax.python:pybin=/correct/binary' to distribution_static__bltnopts."
         echo "/usr/bin/python"
         return 2


### PR DESCRIPTION
Looks like when porting changed from rstatic (a Shellfu/JATS implementation of the same library)  I made two errors relating to the same call -- emitting a warning + hint when Python binary detection fails.

Thanks @lukaszachy for reporting.