### PR TITLE
Add --no-log-init option to useradd

### DIFF
--- a/testUser/lib.sh
+++ b/testUser/lib.sh
@@ -216,7 +216,7 @@ testUserAdd() {
 
     # create
     LogDebug -f "creating first user $newUser"
-    useradd -m $newUser >&2 || ((res++))
+    useradd --no-log-init -m $newUser >&2 || ((res++))
     echo "$newUserPasswd" | passwd --stdin $newUser || ((res++))
 
     # save the users array


### PR DESCRIPTION
testUserAdd causes error when it's called
as part of testUserSetup. --no-log-init should
prevent this error.

```
:: [ 06:28:11 ] :: [  BEGIN   ] :: Running 'testUserSetup'
useradd: failed to reset the lastlog entry of UID 1000: No such file or directory
BAD PASSWORD: The password is shorter than 8 characters
```