### PR TITLE
authconf/lib.sh: Disabling TLS at start

### DIFF
--- a/authconf/lib.sh
+++ b/authconf/lib.sh
@@ -134,6 +134,7 @@ id_provider         = ldap
 auth_provider       = ldap
 #debug_level         = 0xFFFF
 ldap_uri            = $ldapURI
+ldap_id_use_start_tls = false
 
 entry_cache_nowait_percentage       = 0
 entry_cache_timeout                 = 1


### PR DESCRIPTION
* On RHEL-10, there is a TLS error when sssd tries connecting to ldap (openldap): "Could not start TLS encryption. unknown error", disabling TLS solves the problem.