### PR TITLE
Remove deprecated 'U' mode

### DIFF
--- a/static/lib.sh
+++ b/static/lib.sh
@@ -607,7 +607,7 @@ __distribution_static__ck_syntax_python() {
     local path=$1       # path to check file at
     local pybin         # path to python binary
     pybin=$(__distribution_static__ck_syntax_python_guessbin)
-    echo "compile(open('$path', 'rU').read(), '', 'exec')" \
+    echo "compile(open('$path', 'r').read(), '', 'exec')" \
       | rlRun "$pybin - 2>err" \
             0 "$CkName:$path"
     distribution_dump__file -E -s err


### PR DESCRIPTION
Causes fails like:

::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
::   openwsman-python3-2.8.1-3.el10: built-in file-based check: syntax.python
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

:: [ 08:39:10 ] :: [  BEGIN   ] :: syntax.python:/usr/lib64/python3.12/site-packages/pywsman.py :: actually running '/usr/bin/python3 - 2>err'
:: [ 08:39:10 ] :: [   FAIL   ] :: syntax.python:/usr/lib64/python3.12/site-packages/pywsman.py (Expected 0, got 1)
:: [ 08:39:10 ] :: [  ERROR   ] :: =====BEGIN FILE err=====
:: [ 08:39:10 ] :: [  ERROR   ] :: Traceback (most recent call last):
:: [ 08:39:10 ] :: [  ERROR   ] ::   File "<stdin>", line 1, in <module>
:: [ 08:39:10 ] :: [  ERROR   ] :: ValueError: invalid mode: 'rU'
:: [ 08:39:10 ] :: [  ERROR   ] :: =====END FILE err=====
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
::   Duration: 1s
::   Assertions: 0 good, 1 bad
::   RESULT: FAIL (openwsman-python3-2.8.1-3.el10: built-in file-based check: syntax.python)